### PR TITLE
CB-6957 Style improvements on Manual tests

### DIFF
--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.apache.cordova.battery-status.tests"
+    version="0.2.10-dev">
+    <name>Cordova Battery Plugin Tests</name>
+    <license>Apache 2.0</license>
+
+    <js-module src="tests.js" name="tests">
+    </js-module>
+</plugin>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -515,7 +515,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     div.setAttribute("align", "center");
     contentEl.appendChild(div);
 
-    batteryTable = generateTable('info', 5, 3, batteryElements);
+    var batteryTable = generateTable('info', 5, 3, batteryElements);
     contentEl.appendChild(batteryTable);
     
     div = document.createElement('h2');
@@ -523,7 +523,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     div.setAttribute("align", "center");
     contentEl.appendChild(div);
     
-    batteryActionsTable = generateTable('batteryContent', 6, 2, batteryActions);
+    var batteryActionsTable = generateTable('batteryContent', 6, 2, batteryActions);
     contentEl.appendChild(batteryActionsTable);
 
     createActionButton('Add "batterystatus" listener', function () {


### PR DESCRIPTION
Usage of info, which is wired a css class, aimed to only show results.
Reorganization of titles and tables.
Just organization of labes, and html elements.
Requires the changes on this PR:
apache/cordova-plugin-test-framework#3

To get a better look.

Also, renamed folder to tests + added nested plugin.xml
