### PR TITLE
CB-8831 Adds extra check for available API on Windows

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -107,7 +107,7 @@
             <runs />
         </js-module>
         
-        <framework src="src/windows/BatteryStatus.winmd" custom="true"/>
+        <framework src="src/windows/BatteryStatus.winmd" custom="true" target="phone"/>
     </platform>
 
     <!-- tizen -->

--- a/src/windows/BatteryProxy.js
+++ b/src/windows/BatteryProxy.js
@@ -34,13 +34,15 @@ function handleResponse(successCb, errorCb, jsonResponse) {
 
 var Battery = {
     start: function (win, fail, args, env) {
+        // Battery API supported on Phone devices only so in case of
+        // desktop/tablet the only one choice is to fail with appropriate message.
+        if (!WinJS.Utilities.isPhone) {
+            fail("The operation is not supported on Windows Desktop devices.");
+            return;
+        }
+
         stopped = false;
         try {
-            if (!WinJS.Utilities.isPhone) {
-                fail("The operation is not supported by this platform.");
-                return;
-            }
-
             function getBatteryStatus(success, error) {
                 handleResponse(success, error, BatteryStatus.BatteryStatus.start());
             }
@@ -68,6 +70,12 @@ var Battery = {
     },
 
     stop: function () {
+        // Battery API supported on Phone devices only so in case of
+        // desktop/tablet device we don't need for any actions.
+        if (!WinJS.Utilities.isPhone) {
+            return;
+        }
+
         stopped = true;
         BatteryStatus.BatteryStatus.stop();
     }


### PR DESCRIPTION
* This adds check for Phone device to avoid calling missing API (since it is supported on Phone devices only).
* It also removes excess references to winMD assembly from Windows8 and Windows8.1 projects due to the same reason.