### PR TITLE
Alignment with W3C Battery API

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,6 +31,10 @@
     <js-module src="www/battery.js" name="battery">
         <clobbers target="navigator.battery" />
     </js-module>
+
+    <js-module src="www/getBattery.js" name="getBattery">
+        <clobbers target="navigator.getBattery" />
+    </js-module>
     
     <!-- android -->
     <platform name="android">

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -312,7 +312,7 @@ exports.defineAutoTests = function () {
 
             it("battery.spec.4.4 should not fire batterycritical event (6 -> 5) if charging", function (done) {
                 if (isWindowsStore) {
-                    pending('Battery status is not supported on windows store');
+                    pending("Battery status is not supported on windows store");
                 }
 
                 onEvent = jasmine.createSpy("BatteryCritical");
@@ -337,7 +337,466 @@ exports.defineAutoTests = function () {
             });
         });
     });
+
+    describe("Battery (navigator.getBattery)", function () {
+        it("battery.spec.5 should exist", function () {
+            if (isWindowsStore) {
+                pending("Battery status is not supported on windows store");
+            }
+
+            expect(navigator.getBattery() ).toBeDefined();
+        });
+
+        it("battery.spec.5.1 should be promise", function () {
+            if (isWindowsStore) {
+                pending("Battery status is not supported on windows store");
+            }
+
+            navigator.getBattery().then(function(battery) {
+                expect(battery).toBeDefined();
+            }, function(reason) {
+              done(new Error("Promise should  be resolved")); // Success
+            });
+        });
+    });
+
+   describe("GetBattery Events", function () {
+
+        describe("chargingchange", function () {
+
+            afterEach(function (done) {
+                if (!isWindowsStore) {
+                    try {
+                        navigator.getBattery().then(function(battery) {
+                            battery.removeEventListener("chargingchange", onEvent);
+                            done();
+                        }, function(reason) {
+                            done(new Error("Promise should be resolved")); 
+                        });
+                    }
+                    catch (e) {
+                        console.err("Error removing batterystatus event listener: " + e);
+                    }
+                }
+            });
+
+            it("battery.spec.6 should fire chargingchange events", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+                onEvent = jasmine.createSpy("Chargingchange");
+
+                navigator.getBattery().then(function(battery) {
+                    battery.addEventListener("chargingchange", onEvent);
+                    battery._status({
+                        level : 0.8,
+                        charging : false
+                    });
+                    setTimeout(function () {
+                        battery._status({
+                            level : 0.81,
+                            charging : true
+                        });
+                    }, 0);
+                  
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).toHaveBeenCalled();
+                    done();
+                }, 100);
+                 
+            });
+
+
+            it("battery.spec.6.1 level should be between 0 and 1", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+                onEvent = jasmine.createSpy("Chargingchange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    batteryManager = battery;
+                    battery.addEventListener("chargingchange", onEvent);
+                    battery._status({
+                        level : 0.9,
+                        charging : true
+                    });
+                }, function(reason) {
+                  done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(batteryManager.level >= 0).toBeTruthy();
+                    expect(batteryManager.level <= 1).toBeTruthy();
+                    done();
+                }, 100);
+              
+            });
+        });
+
+        describe("chargingtimechange without device information", function () {
+
+            afterEach(function (done) {
+                if (!isWindowsStore) {
+                    try {
+                        navigator.getBattery().then(function(battery) {
+                            battery.removeEventListener("chargingtimechange", onEvent);
+                            done();
+                        }, function(reason) {
+                          done(new Error("Promise should be resolved")); 
+                        });
+                    }
+                    catch (e) {
+                        console.err("Error removing chargingtimechange event listener: " + e);
+                    }
+                }
+            });
+
+            it("battery.spec.7 should equal 0 if no information", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+                onEvent = jasmine.createSpy("Chargingtimechange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    battery.addEventListener("chargingtimechange", onEvent);
+                    batteryManager = battery;
+                    battery._status({
+                        level : 0.9,
+                        charging : true
+                    });
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).not.toHaveBeenCalled();
+                    //Is a number and not a string
+                    expect(batteryManager.chargingTime).toEqual(0);    
+                    done();
+                }, 100);
+      
+            });
+        });
+        
+        describe("chargingtimechange with device information", function () {
+
+            afterEach(function (done) {
+                if (!isWindowsStore) {
+                    try {
+                        navigator.getBattery().then(function(battery) {
+                            battery.removeEventListener("chargingtimechange", onEvent);
+                            done();
+                        }, function(reason) {
+                          done(new Error("Promise should be resolved")); 
+                        });
+                    }
+                    catch (e) {
+                        console.err("Error removing chargingtimechange event listener: " + e);
+                    }
+                }
+            });
+
+            it("battery.spec.8 should fire chargingtimechange event when charging ", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("Chargingtimechange");
+                navigator.getBattery().then(function(battery) {
+
+                    battery.addEventListener("chargingtimechange", onEvent);
+                    battery._status({
+                        level : 0.9,
+                        charging : true,
+                        chargingTime : 30
+                    });
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).toHaveBeenCalled();
+                    done();
+                }, 100);
+
+            });
+
+            it("battery.spec.8.1 should fire chargingtimechange when dicharging and be equal positive Infinity", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("Chargingtimechange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    batteryManager = battery;
+                    battery.addEventListener("chargingtimechange", onEvent);
+                    battery._status({
+                        level : 0.9,
+                        charging : false,
+                        chargingTime :"positive Infinity"
+                    });
+  
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).toHaveBeenCalled(); 
+                    expect(batteryManager.chargingTime).toEqual("positive Infinity");        
+                    done();
+                }, 100);
+            });
+
+            it("battery.spec.8.2 should fire chargingtimechange when battery is full and equal 0", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("Chargingtimechange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    batteryManager = battery;
+                    battery.addEventListener("chargingtimechange", onEvent);
+                    battery._status({
+                        level : 0.9,
+                        charging : true
+                    });
+                    setTimeout(function () {
+                        battery._status({
+                            level : 0.81,
+                            charging : true,
+                            chargingTime : 0
+                        });
+                    }, 0);
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).toHaveBeenCalled();
+                    expect(batteryManager.chargingTime).toEqual(0);        
+                    done();
+                }, 100);
+            });
+        });
+
+        describe("dischargingtimechange without device information", function () {
+
+            afterEach(function (done) {
+                if (!isWindowsStore) {
+                    try {
+                        navigator.getBattery().then(function(battery) {
+                            battery.removeEventListener("dischargingtimechange", onEvent);
+                            done();
+                        }, function(reason) {
+                          done(new Error("Promise should  be resolved")); 
+                        });
+                    }
+                    catch (e) {
+                        console.err("Error removing dischargingtimechange event listener: " + e);
+                    }
+                }
+            });
+
+            it("battery.spec.9 should equal positive Infinity ", function (done) {
+               if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("Dischargingtimechange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    battery.addEventListener("dischargingtimechange", onEvent);
+                    batteryManager = battery;
+                    battery._status({
+                        level : 0.9,
+                        charging : false,
+                        dischargingTime : "positive Infinity"
+                    });
+                }, function(reason) {
+                    done(new Error("Promise should  be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).not.toHaveBeenCalled();  
+                    //Is a number and not a string
+                    expect(batteryManager.dischargingTime).toEqual("positive Infinity");   
+                    done();
+                }, 100);
+
+            });
+        });
+
+        describe("dischargingtimechange with device information", function () {
+            afterEach(function (done) {
+                if (!isWindowsStore) {
+                    try {
+                        navigator.getBattery().then(function(battery) {
+                            battery.removeEventListener("dischargingtimechange", onEvent);
+                            done();
+                        }, function(reason) {
+                          done(new Error("Promise should  be resolved")); 
+                        });
+                    }
+                    catch (e) {
+                        console.err("Error removing dischargingtimechange event listener: " + e);
+                    }
+                }
+            });
+
+            it("battery.spec.10 should fire ondischargingtimechange event when discharging and equal number ", function (done) {
+               if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("Dischargingtimechange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    battery.addEventListener("dischargingtimechange", onEvent);
+                    batteryManager = battery;
+                    battery._status({
+                        level : 0.9,
+                        charging : false,
+                        dischargingTime : 456
+                    });
+                }, function(reason) {
+                    done(new Error("Promise should  be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).toHaveBeenCalled();  
+                    //Is a number and not a string
+                    expect(batteryManager.dischargingTime).toMatch(/\d{1,}/);   
+                    done();
+                }, 100);
+
+            });
+            
+
+             it("battery.spec.10.1 should fire ondischargingtimechange when charging and be equal positive Infinity", function (done) {
+                if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("Dischargingtimechange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    batteryManager = battery;
+                    battery.addEventListener("dischargingtimechange", onEvent);
+                    battery._status({
+                        level : 0.89,
+                        charging : true,
+                        dischargingTime : "positive Infinity"
+                    });
+                }, function(reason) {
+                    done(new Error("Promise should  be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).toHaveBeenCalled(); 
+                    expect(batteryManager.dischargingTime).toEqual("positive Infinity");        
+                    done();
+                }, 100);
+            });
+        });
+        describe("levelchange", function () {
+            afterEach(function (done) {
+                if (!isWindowsStore) {
+                    try {
+                        navigator.getBattery().then(function(battery) {
+                            battery.removeEventListener("levelChange", onEvent);
+                            done();
+                        }, function(reason) {
+                          done(new Error("Promise should be resolved")); 
+                        });
+                    }
+                    catch (e) {
+                        console.err("Error removing dischargingtimechange event listener: " + e);
+                    }
+                }
+            });
+
+            it("battery.spec.11 should fire levelChange event when charging", function (done) {
+               if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("LevelChange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    battery.addEventListener("levelChange", onEvent);
+                    batteryManager = battery;
+                    battery._status({
+                        level : 0.9,
+                        charging : true,
+                        dischargingTime : "positive Infinity"
+                    });
+
+                    setTimeout(function () {
+                        battery._status({
+                            level : 0.92,
+                            charging : true,
+                            dischargingTime : "positive Infinity"
+                        });  
+                        done();
+                    }, 0);      
+
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).not.toHaveBeenCalled();  
+                    done();
+                }, 100);
+
+            });
+
+            it("battery.spec.11.1 should fire levelChange event when discharging", function (done) {
+               if (isWindowsStore) {
+                    pending("Battery status is not supported on windows store");
+                }
+
+                onEvent = jasmine.createSpy("LevelChange");
+                var batteryManager = null;
+                navigator.getBattery().then(function(battery) {
+                    battery.addEventListener("levelChange", onEvent);
+                    batteryManager = battery;
+                    battery._status({
+                        level : 0.9,
+                        charging : false,
+                        dischargingTime : "positive Infinity"
+                    });
+
+                    setTimeout(function () {
+                        battery._status({
+                            level : 0.85,
+                            charging : false,
+                            dischargingTime : "positive Infinity"
+                        });  
+                        done();
+                    }, 0);      
+
+                }, function(reason) {
+                    done(new Error("Promise should be resolved")); 
+                });
+
+                setTimeout(function () {
+                    expect(onEvent).not.toHaveBeenCalled();  
+                    done();
+                }, 100);
+
+            });
+        });
+
+    });
 };
+
 
 //******************************************************************************************
 //***************************************Manual Tests***************************************
@@ -387,6 +846,93 @@ exports.defineManualTests = function (contentEl, createActionButton) {
 
     function removeCritical() {
         window.removeEventListener("batterycritical", batteryCritical, false);
+    }
+
+
+    /* getBattery */
+    function charingchange() {
+        document.getElementById('lowValue').innerText = "true";
+    }
+
+    function chargingtimechange() {
+        document.getElementById('criticalValue').innerText = "true";
+    } 
+
+    function dischargingtimechange() {
+        document.getElementById('lowValue').innerText = "true";
+    }
+
+    function levelchange() {
+        document.getElementById('criticalValue').innerText = "true";
+    }
+
+
+    function addChargingchange() {
+        navigator.getBattery().then(function(battery) {
+            battery.addEventListener("chargingchange", charingchange);
+        }, function(reason) {
+            done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function removeChargingchange() {
+        navigator.getBattery().then(function(battery) {
+            battery.removeEventListener("chargingchange", charingchange);
+            done();
+        }, function(reason) {
+          done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function addChargingtimechange() {
+        navigator.getBattery().then(function(battery) {
+            battery.addEventListener("chargingtimechange", chargingtimechange);
+        }, function(reason) {
+            done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function removeChargingtimechange() {
+        navigator.getBattery().then(function(battery) {
+            battery.removeEventListener("chargingtimechange", chargingtimechange);
+            done();
+        }, function(reason) {
+          done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function addDischargingtimechange() {
+        navigator.getBattery().then(function(battery) {
+            battery.addEventListener("dischargingtimechange", dischargingtimechange);
+        }, function(reason) {
+            done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function removeDischargingtimechange() {
+        navigator.getBattery().then(function(battery) {
+            battery.removeEventListener("dischargingtimechange", dischargingtimechange);
+            done();
+        }, function(reason) {
+          done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function addLevelchange() {
+        navigator.getBattery().then(function(battery) {
+            battery.addEventListener("levelchange", levelchange);
+        }, function(reason) {
+            done(new Error("Promise should be resolved")); 
+        });
+    }
+
+    function removeLevelchange() {
+        navigator.getBattery().then(function(battery) {
+            battery.removeEventListener("levelchange", levelchange);
+            done();
+        }, function(reason) {
+          done(new Error("Promise should be resolved")); 
+        });
     }
 
     //Generate Dynamic Table
@@ -534,6 +1080,19 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('Remove "batterystatus" listener', function () {
         removeBattery();
     }, 'remBs');
+    createActionButton('Add "batterylow" listener', function () {
+        addLow();
+    }, 'addBl');
+    createActionButton('Remove "batterylow" listener', function () {
+        removeLow();
+    }, 'remBl');
+    createActionButton('Add "batterycritical" listener', function () {
+        addCritical();
+    }, 'addBc');
+    createActionButton('Remove "batterycritical" listener', function () {
+        removeCritical();
+    }, 'remBc');
+    /* getBattery */
     createActionButton('Add "batterylow" listener', function () {
         addLow();
     }, 'addBl');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -851,19 +851,35 @@ exports.defineManualTests = function (contentEl, createActionButton) {
 
     /* getBattery */
     function charingchange() {
-        document.getElementById('lowValue').innerText = "true";
+        navigator.getBattery().then(function(battery) {
+            document.getElementById('chargingValue').innerText = (battery.charging ? "Yes" : "No");
+        }).catch(function(error) {
+            console.log("Failed to get Battery information!", error);
+        });
     }
 
     function chargingtimechange() {
-        document.getElementById('criticalValue').innerText = "true";
+        navigator.getBattery().then(function(battery) {
+            document.getElementById('chargingTimeValue').innerText = battery.chargingTime;
+        }).catch(function(error) {
+            console.log("Failed to get Battery information!", error);
+        });    
     } 
 
     function dischargingtimechange() {
-        document.getElementById('lowValue').innerText = "true";
+        navigator.getBattery().then(function(battery) {
+            document.getElementById('dischargingTimeValue').innerText = battery.dischargingTime;
+        }).catch(function(error) {
+            console.log("Failed to get Battery information!", error);
+        });    
     }
 
     function levelchange() {
-        document.getElementById('criticalValue').innerText = "true";
+        navigator.getBattery().then(function(battery) {
+            document.getElementById('levelValue').innerText = battery.level;
+        }).catch(function(error) {
+            console.log("Failed to get Battery information!", error);
+        });  
     }
 
 
@@ -871,50 +887,49 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         navigator.getBattery().then(function(battery) {
             battery.addEventListener("chargingchange", charingchange);
         }, function(reason) {
-            done(new Error("Promise should be resolved")); 
+            return new Error("Promise should be resolved"); 
         });
     }
 
     function removeChargingchange() {
         navigator.getBattery().then(function(battery) {
             battery.removeEventListener("chargingchange", charingchange);
-            done();
         }, function(reason) {
-          done(new Error("Promise should be resolved")); 
+            return new Error("Promise should be resolved"); 
         });
     }
 
     function addChargingtimechange() {
         navigator.getBattery().then(function(battery) {
             battery.addEventListener("chargingtimechange", chargingtimechange);
+            document.getElementById('chargingTimeValue').innerText = battery.chargingTime;
         }, function(reason) {
-            done(new Error("Promise should be resolved")); 
+            return new Error("Promise should be resolved"); 
         });
     }
 
     function removeChargingtimechange() {
         navigator.getBattery().then(function(battery) {
             battery.removeEventListener("chargingtimechange", chargingtimechange);
-            done();
         }, function(reason) {
-          done(new Error("Promise should be resolved")); 
+            return new Error("Promise should be resolved"); 
         });
     }
 
     function addDischargingtimechange() {
         navigator.getBattery().then(function(battery) {
             battery.addEventListener("dischargingtimechange", dischargingtimechange);
+            document.getElementById("dischargingTimeValue").innerText = battery.dischargingTime;
         }, function(reason) {
-            done(new Error("Promise should be resolved")); 
+            return new Error("Promise should be resolved"); 
         });
     }
 
     function removeDischargingtimechange() {
         navigator.getBattery().then(function(battery) {
             battery.removeEventListener("dischargingtimechange", dischargingtimechange);
-            done();
         }, function(reason) {
-          done(new Error("Promise should be resolved")); 
+          return new Error("Promise should be resolved"); 
         });
     }
 
@@ -922,16 +937,15 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         navigator.getBattery().then(function(battery) {
             battery.addEventListener("levelchange", levelchange);
         }, function(reason) {
-            done(new Error("Promise should be resolved")); 
+            return new Error("Promise should be resolved"); 
         });
     }
 
     function removeLevelchange() {
         navigator.getBattery().then(function(battery) {
             battery.removeEventListener("levelchange", levelchange);
-            done();
         }, function(reason) {
-          done(new Error("Promise should be resolved")); 
+         return new Error("Promise should be resolved"); 
         });
     }
 
@@ -1047,6 +1061,54 @@ exports.defineManualTests = function (contentEl, createActionButton) {
                 row : 4,
                 cell : 1
             }
+        }, {
+            id : "chargingTag",
+            content : "Charging:",
+            tag : "div",
+            position : {
+                row : 5,
+                cell : 0
+            }
+        }, {
+            id : "chargingValue",
+            content : "",
+            tag : "div",
+            position : {
+                row : 5,
+                cell : 1
+            }
+        }, {
+            id : "chargingTimeTag",
+            content : "ChargingTime:",
+            tag : "div",
+            position : {
+                row : 6,
+                cell : 0
+            }
+        }, {
+            id : "chargingTimeValue",
+            content : "",
+            tag : "div",
+            position : {
+                row : 6,
+                cell : 1
+            }
+        }, {
+            id : "dischargingTimeTag",
+            content : "DischargingTime:",
+            tag : "div",
+            position : {
+                row : 7,
+                cell : 0
+            }
+        }, {
+            id : "dischargingTimeValue",
+            content : "",
+            tag : "div",
+            position : {
+                row : 7,
+                cell : 1
+            }
         }
     ];
 
@@ -1056,7 +1118,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     div.setAttribute("align", "center");
     contentEl.appendChild(div);
 
-    var batteryTable = generateTable('info', 5, 3, batteryElements);
+    var batteryTable = generateTable('info', 8, 3, batteryElements);
     contentEl.appendChild(batteryTable);
 
     div = document.createElement('h2');
@@ -1072,7 +1134,21 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '<div id="addBl"></div><div id="remBl"></div>' +
         '<h3>Battery Critical Tests</h3>' +
         '</p> Will update value for battery critical to true when battery is below 5%' +
-        '<div id="addBc"></div><div id="remBc"></div>';
+        '<div id="addBc"></div><div id="remBc"></div>' ;
+
+    //getBattery
+    contentEl.innerHTML += '<h3>Battery charging Tests</h3>' +
+        '</p>  Will update value for batteryManger charging if battery is charging or discharging' +
+        '<div id="addCc"></div><div id="remCc"></div>' +
+        '<h3>Battery chargingTime Tests</h3>' +
+        '</p> Will update value for batteryManger chargingTime when it change' +
+        '<div id="addCtc"></div><div id="remCtc"></div>' +
+        '<h3>Battery dischargingtimechange Tests</h3>' +
+        '</p> Will update value for batteryManger dischargingTime when it change' +
+        '<div id="addDtc"></div><div id="remDtc"></div>' +
+        '<h3>Battery levelchange Tests</h3>' +
+        '</p> Will update value for batteryManger level when it change' +
+        '<div id="addLc"></div><div id="remLc"></div>';
 
     createActionButton('Add "batterystatus" listener', function () {
         addBattery();
@@ -1092,17 +1168,31 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('Remove "batterycritical" listener', function () {
         removeCritical();
     }, 'remBc');
+
     /* getBattery */
-    createActionButton('Add "batterylow" listener', function () {
-        addLow();
-    }, 'addBl');
-    createActionButton('Remove "batterylow" listener', function () {
+    createActionButton('Add "chargingchange" listener', function () {
+        addChargingchange();
+    }, 'addCc');
+    createActionButton('Remove "chargingchange" listener', function () {
         removeLow();
-    }, 'remBl');
-    createActionButton('Add "batterycritical" listener', function () {
-        addCritical();
-    }, 'addBc');
-    createActionButton('Remove "batterycritical" listener', function () {
-        removeCritical();
-    }, 'remBc');
+    }, 'remCc');
+    createActionButton('Add "chargingtimechange" listener', function () {
+        addChargingtimechange();
+    }, 'addCtc');
+    createActionButton('Remove "chargingtimechange" listener', function () {
+        removeChargingtimechange();
+    }, 'remCtc');
+
+    createActionButton('Add "dischargingtimechange" listener', function () {
+        addDischargingtimechange();
+    }, 'addDtc');
+    createActionButton('Remove "dischargingtimechange" listener', function () {
+        removeDischargingtimechange();
+    }, 'remDtc');
+    createActionButton('Add "levelchange" listener', function () {
+        addLevelchange();
+    }, 'addLc');
+    createActionButton('Remove "levelchange" listener', function () {
+        removeLevelchange();
+    }, 'remLc');
 };

--- a/www/getBattery.js
+++ b/www/getBattery.js
@@ -1,0 +1,81 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var cordova = require('cordova'),
+    exec = require('cordova/exec'),
+    channel = require('cordova/channel');
+
+/**
+* This class contains information about the current battery status.
+*/
+var BatteryManager = function() {
+    //The level value:
+    // must be set to 0 if the system's battery is depleted and the system is about to be suspended, 
+    //and to 1.0 if the battery is full, 
+    this._level = 1.0;
+
+    //The charging value : 
+    //- false if the battery is discharging or full
+    //- set to true if the battery is charging
+    this._charging = true;
+
+    //ChargingTime value : 
+    //- 0 if the battery is full or if there is no battery attached to the system
+    //- positive Infinity if the battery is discharging,
+    this._chargingTime = 0;
+
+    //_dischargingTime value : 
+    //- positive Infinity, if the battery is charging
+    //- positive Infinity if the battery is discharging,
+    this._dischargingTime = "positive Infinity";
+};
+
+
+var batteryManager = new BatteryManager();
+//Readonly properties
+Object.defineProperty(batteryManager, "charging", {
+    get : function () { return batteryManager._charging; }
+});
+Object.defineProperty(batteryManager, "chargingTime", {
+    get : function () { return batteryManager._chargingTime; }
+});
+Object.defineProperty(batteryManager, "dischargingTime", {
+    get : function () { return batteryManager._dischargingTime; }
+});
+Object.defineProperty(batteryManager, "level", {
+    get : function () { return batteryManager._level; }
+});
+
+
+function getBattery() {
+    return new Promise(
+        function (resolve, reject) {
+            if (batteryManager) {
+                resolve(batteryManager);
+            } else {
+                reject("Not Support");
+            }
+        }
+    );
+}
+
+module.exports = getBattery;
+

--- a/www/getBattery.js
+++ b/www/getBattery.js
@@ -119,6 +119,11 @@ BatteryManager.prototype._status = function (info) {
             return; // special case where callback is called because we stopped listening to the native side.
         }
 
+        //level must be between 0 and 1.0 
+        if (info.level > 1) {
+            info.level = (info.level / 100);
+        }
+
         if (!info.hasOwnProperty('charging')) {
             info.charging = info.isPlugged;
         }


### PR DESCRIPTION
Addition of the methode navigator.getBattery which return a BatteryManager object using promises to align with the [W3C API](http://www.w3.org/TR/battery-status/)

Here is the associate  [Jira issue](https://issues.apache.org/jira/browse/CB-6065).

Some notes on the proposed changes:
* The previous navigator.battery and the new navigator.getBattery can't run together on android ( only one callbackContext allowed with the current version)
* chargingtime and dischargingtime value aren't available for now (since that data is not provided by default at least on Android and FirefoxOS)

Also, I was not clear whether there is  a coding guideline (formatting, etc) ? I tried to keep it close to the original