### PR TITLE
CB-10645 The battery status handler doesn't reinitialize on Android after window.location.reload()

### DIFF
--- a/src/android/BatteryListener.java
+++ b/src/android/BatteryListener.java
@@ -57,8 +57,7 @@ public class BatteryListener extends CordovaPlugin {
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         if (action.equals("start")) {
             if (this.batteryCallbackContext != null) {
-                callbackContext.error( "Battery listener already running.");
-                return true;
+                removeBatteryListener();
             }
             this.batteryCallbackContext = callbackContext;
 


### PR DESCRIPTION
Instead of throwing an error, rather remove the status handler and re-initialize.
