### PR TITLE
Reorganizing and rewording docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,33 +21,36 @@
 
 # cordova-plugin-battery-status
 
-
-This plugin provides an implementation of an old version of the [Battery Status Events API](http://www.w3.org/TR/2011/WD-battery-status-20110915/).
-
-It adds the following three `window` events:
+This plugin provides an implementation of an old version of the [Battery Status Events API][w3c_spec]. It adds the following three events to the `window` object:
 
 * batterystatus
 * batterycritical
 * batterylow
 
+Applications may use `window.addEventListener` to attach an event listener for any of the above events after the `deviceready` event fires.
+
 ## Installation
 
     cordova plugin add cordova-plugin-battery-status
 
-## batterystatus
+## Status object
 
-This event fires when the percentage of battery charge changes by at
-least 1 percent, or if the device is plugged in or unplugged.
+All events in this plugin return an object with the following properties:
 
-The battery status handler is passed an object that contains two
-properties:
-
-- __level__: The percentage of battery charge (0-100). _(Number)_
-
+- __level__: The battery charge percentage (0-100). _(Number)_
 - __isPlugged__: A boolean that indicates whether the device is plugged in. _(Boolean)_
 
-Applications typically should use `window.addEventListener` to
-attach an event listener after the `deviceready` event fires.
+## batterystatus event
+
+Fires when the battery charge percentage changes by at least 1 percent, or when the device is plugged in or unplugged. Returns an [object][status_object] containing battery status.
+
+### Example
+
+    window.addEventListener("batterystatus", onBatteryStatus, false);
+
+    function onBatteryStatus(status) {
+        console.log("Level: " + status.level + " isPlugged: " + status.isPlugged);
+    }
 
 ### Supported Platforms
 
@@ -57,120 +60,72 @@ attach an event listener after the `deviceready` event fires.
 - BlackBerry 10
 - Windows Phone 7 and 8
 - Windows (Windows Phone 8.1 only)
-- Tizen
 - Firefox OS
-- Browser
+- Browser (Chrome, Firefox, Opera)
 
-### Android and Amazon Fire OS Quirks
+### Quirks: Android &amp; Amazon Fire OS
 
-- Warning: the Android + Fire OS implementations are greedy and prolonged use will drain the user's battery. 
+**Warning**: the Android and Fire OS implementations are greedy and prolonged use will drain the device's battery.
 
-### Windows Phone 7 and 8 Quirks
+### Quirks: Windows Phone 7 &amp; Windows Phone 8
 
-Windows Phone 7 does not provide native APIs to determine battery
-level, so the `level` property is unavailable.  The `isPlugged`
-parameter _is_ supported.
+The `level` property is _not_ supported on Windows Phone 7 because the OS does not provide native APIs to determine battery level. The `isPlugged` parameter _is_ supported.
 
-### Windows Quirks
+### Quirks: Windows Phone 8.1
 
-Windows Phone 8.1 does not support `isPlugged` parameter.
-The `level` parameter _is_ supported.
+The `isPlugged` parameter is _not_ supported on Windows Phone 8.1. The `level` parameter _is_ supported.
 
-### Browser Quirks
+## batterylow event
 
-Supported browsers are Chrome, Firefox and Opera. 
-
-### Example
-
-    window.addEventListener("batterystatus", onBatteryStatus, false);
-
-    function onBatteryStatus(info) {
-        // Handle the online event
-        console.log("Level: " + info.level + " isPlugged: " + info.isPlugged);
-    }
-
-## batterycritical
-
-The event fires when the percentage of battery charge has reached the
-critical battery threshold. The value is device-specific.
-
-The `batterycritical` handler is passed an object that contains two
-properties:
-
-- __level__: The percentage of battery charge (0-100). _(Number)_
-
-- __isPlugged__: A boolean that indicates whether the device is plugged in. _(Boolean)_
-
-Applications typically should use `window.addEventListener` to attach
-an event listener once the `deviceready` event fires.
-
-### Supported Platforms
-
-- Amazon Fire OS
-- iOS
-- Android
-- BlackBerry 10
-- Tizen
-- Firefox OS
-- Windows (Windows Phone 8.1 only)
-- Browser
-
-### Windows Quirks
-
-Windows Phone 8.1 will fire `batterycritical` event regardless of plugged state as it is not supported.
-
-### Example
-
-    window.addEventListener("batterycritical", onBatteryCritical, false);
-
-    function onBatteryCritical(info) {
-        // Handle the battery critical event
-        alert("Battery Level Critical " + info.level + "%\nRecharge Soon!");
-    }
-
-### Browser Quirks
-
-Supported browsers are Chrome, Firefox and Opera. 
-
-## batterylow
-
-The event fires when the percentage of battery charge has reached the
-low battery threshold, device-specific value.
-
-The `batterylow` handler is passed an object that contains two
-properties:
-
-- __level__: The percentage of battery charge (0-100). _(Number)_
-
-- __isPlugged__: A boolean that indicates whether the device is plugged in. _(Boolean)_
-
-Applications typically should use `window.addEventListener` to
-attach an event listener once the `deviceready` event fires.
-
-### Supported Platforms
-
-- Amazon Fire OS
-- iOS
-- Android
-- BlackBerry 10
-- Tizen
-- Firefox OS
-- Windows (Windows Phone 8.1 only)
-- Browser
-
-### Windows Quirks
-
-Windows Phone 8.1 will fire `batterylow` event regardless of plugged state as it is not supported.
+Fires when the battery charge percentage reaches the low charge threshold. This threshold value is device-specific. Returns an [object][status_object] containing battery status.
 
 ### Example
 
     window.addEventListener("batterylow", onBatteryLow, false);
 
-    function onBatteryLow(info) {
-        // Handle the battery low event
-        alert("Battery Level Low " + info.level + "%");
+    function onBatteryLow(status) {
+        alert("Battery Level Low " + status.level + "%");
     }
 
-### Browser Quirks
+### Supported Platforms
 
-Supported browsers are Chrome, Firefox and Opera. 
+- Amazon Fire OS
+- iOS
+- Android
+- BlackBerry 10
+- Firefox OS
+- Windows (Windows Phone 8.1 only)
+- Browser (Chrome, Firefox, Opera)
+
+### Quirks: Windows Phone 8.1
+
+The `batterylow` event fires on Windows Phone 8.1 irrespective of whether the device is plugged in or not. This happens because the OS does not provide an API to detect whether the device is plugged in.
+
+## batterycritical event
+
+Fires when the battery charge percentage reaches the critical charge threshold. This threshold value is device-specific. Returns an [object][status_object] containing battery status.
+
+### Example
+
+    window.addEventListener("batterycritical", onBatteryCritical, false);
+
+    function onBatteryCritical(status) {
+        alert("Battery Level Critical " + status.level + "%\nRecharge Soon!");
+    }
+
+### Supported Platforms
+
+- Amazon Fire OS
+- iOS
+- Android
+- BlackBerry 10
+- Firefox OS
+- Windows (Windows Phone 8.1 only)
+- Browser (Chrome, Firefox, Opera)
+
+### Quirks: Windows Phone 8.1
+
+The `batterycritical` event fires on Windows Phone 8.1 irrespective of whether the device is plugged in or not. This happens because the OS does not provide an API to detect whether the device is plugged in.
+
+[w3c_spec]: http://www.w3.org/TR/2011/WD-battery-status-20110915/
+[status_object]: #status-object


### PR DESCRIPTION
- Put examples below events
- De-duped returned object section
- Removed Tizen (deprecated)
- Made quirks a little easier to distinguish
- Switched to using reference-style links
