### PR TITLE
be sure to remove listeners before executing start

### DIFF
--- a/www/battery.js
+++ b/www/battery.js
@@ -57,7 +57,9 @@ function handlers() {
 Battery.onHasSubscribersChange = function() {
   // If we just registered the first handler, make sure native listener is started.
   if (this.numHandlers === 1 && handlers() === 1) {
-      exec(battery._status, battery._error, "Battery", "start", []);
+      exec(function() {
+        exec(battery._status, battery._error, "Battery", "start", []);
+      }, battery._error, "Battery", "stop", []);
   } else if (handlers() === 0) {
       exec(null, null, "Battery", "stop", []);
   }


### PR DESCRIPTION
Hi, thanks for your plugin. Works great for us. Only issue we have that the initial values for `level` and `isPlugged` were not set after a page reload. The native part already registered the listeners and did not update the js part.

regards
