### PR TITLE
CB-11256: (ubuntu) Qt API change breaks the battery plugin

### DIFF
--- a/src/ubuntu/battery.h
+++ b/src/ubuntu/battery.h
@@ -25,6 +25,7 @@
 
 #include <cplugin.h>
 
+
 class BatteryStatus: public CPlugin {
     Q_OBJECT
 public:
@@ -47,15 +48,14 @@ public slots:
     void stop(int scId, int ecId);
 
 private slots:
-    void remainingCapacityChanged(int battery, int capacity);
+    void remainingCapacityChanged(int capacity);
+    void batteryCountChanged(int count);
     void chargerTypeChanged(QBatteryInfo::ChargerType type);
-    void onlineStatusChanged(bool isOnline);
 
 private:
     void fireEvents();
 
     QBatteryInfo _batteryInfo;
-
     int _scId;
 };
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

Ubuntu
### What does this PR do?

Fixes the plugin to be compatible with Qt 5.4
### What testing has been done on this change?

Checked on ubuntu devices
### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
