### PR TITLE
CB-8929 (Windows) Now working on Windows 10 mobile devices

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
     <js-module src="www/battery.js" name="battery">
         <clobbers target="navigator.battery" />
     </js-module>
-    
+
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
@@ -53,7 +53,7 @@
 
         <source-file src="src/android/BatteryListener.java" target-dir="src/org/apache/cordova/batterystatus" />
     </platform>
-    
+
     <!-- ubuntu -->
     <platform name="ubuntu">
         <header-file src="src/ubuntu/battery.h" />
@@ -61,10 +61,10 @@
     </platform>
 
     <!-- ios -->
-    <platform name="ios">    
+    <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="Battery">
-                <param name="ios-package" value="CDVBattery" /> 
+                <param name="ios-package" value="CDVBattery" />
             </feature>
         </config-file>
         <header-file src="src/ios/CDVBattery.h" />
@@ -102,12 +102,12 @@
     </platform>
 
     <!-- windows -->
-    <platform name="windows">	
+    <platform name="windows">
         <js-module src="src/windows/BatteryProxy.js" name="Battery">
             <runs />
         </js-module>
-        
-        <framework src="src/windows/BatteryStatus.winmd" custom="true" target="phone"/>
+
+        <framework src="src/windows/BatteryStatus.winmd" custom="true" />
     </platform>
 
     <!-- tizen -->
@@ -123,7 +123,7 @@
             <runs />
         </js-module>
     </platform>
-	
+
     <!-- browser -->
     <platform name="browser">
         <js-module src="src/browser/BatteryProxy.js" name="Battery">

--- a/src/windows/BatteryProxy.js
+++ b/src/windows/BatteryProxy.js
@@ -19,9 +19,10 @@
  *
  */
 
-/* global WinJS, BatteryStatus */
+/* global BatteryStatus */
 
 var stopped;
+var batteryApiSupported = true;
 
 function handleResponse(successCb, errorCb, jsonResponse) {
     var info = JSON.parse(jsonResponse);
@@ -54,26 +55,27 @@ var Battery = {
             });
         }
 
-        // Battery API supported on Phone devices only so in case of
-        // desktop/tablet the only one choice is to fail with appropriate message.
-        if (!WinJS.Utilities.isPhone) {
-            fail("The operation is not supported on Windows Desktop devices.");
-            return;
-        }
-
         stopped = false;
         try {
             getBatteryStatus(win, fail);
             getBatteryStatusLevelChangeEvent(win, fail);
-        } catch(e) {
-            fail(e);
+        } catch (e) {
+            if (e.message.indexOf("System.TypeLoadException") >= 0) {
+                // Battery API is supported only on Phone devices
+                batteryApiSupported = false;
+                fail("This operation is not supported on this device.");
+                return;
+            } else {
+                fail(e.message);
+            }
+
         }
     },
 
     stop: function () {
         // Battery API supported on Phone devices only so in case of
         // desktop/tablet device we don't need for any actions.
-        if (!WinJS.Utilities.isPhone) {
+        if (!batteryApiSupported) {
             return;
         }
 


### PR DESCRIPTION
### Platforms affected
Windows

### What does this PR do?
Fixes battery-status plugin now working on Windows 10 devices

### What testing has been done on this change?
Tested on Lumia 1520 and Windows 10 Desktop

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

