### PR TITLE
CB-8929 Use PowerManager to get battery state on Win 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Fires when the battery charge percentage changes by at least 1 percent, or when 
 - Android
 - BlackBerry 10
 - Windows Phone 7 and 8
-- Windows (Windows Phone 8.1 only)
+- Windows (Windows Phone 8.1 and Windows 10)
 - Firefox OS
 - Browser (Chrome, Firefox, Opera)
 
@@ -100,7 +100,7 @@ Fires when the battery charge percentage reaches the low charge threshold. This 
 - Android
 - BlackBerry 10
 - Firefox OS
-- Windows (Windows Phone 8.1 only)
+- Windows (Windows Phone 8.1 and Windows 10)
 - Browser (Chrome, Firefox, Opera)
 
 ### Quirks: Windows Phone 8.1
@@ -126,7 +126,7 @@ Fires when the battery charge percentage reaches the critical charge threshold. 
 - Android
 - BlackBerry 10
 - Firefox OS
-- Windows (Windows Phone 8.1 only)
+- Windows (Windows Phone 8.1 and Windows 10)
 - Browser (Chrome, Firefox, Opera)
 
 ### Quirks: Windows Phone 8.1

--- a/src/windows/BatteryProxy.js
+++ b/src/windows/BatteryProxy.js
@@ -19,7 +19,38 @@
  *
  */
 
-/* global WinJS, BatteryStatus */
+/* global Windows, WinJS, BatteryStatus */
+
+var PowerManager = Windows && Windows.System &&
+    Windows.System.Power && Windows.System.Power.PowerManager;
+
+if (PowerManager) {
+    var BatteryWin10 = {
+        start: function (win, fail) {
+
+            function reportStatus() {
+                win({
+                    level: PowerManager.remainingChargePercent,
+                    isPlugged: PowerManager.powerSupplyStatus !== Windows.System.Power.PowerSupplyStatus.notPresent
+                }, { keepCallback: true });
+            }
+
+            PowerManager.onremainingchargepercentchanged = reportStatus;
+            PowerManager.onpowersupplystatuschanged = reportStatus;
+
+            reportStatus();
+        },
+
+        stop: function () {
+            PowerManager.onremainingchargepercentchanged = null;
+            PowerManager.onpowersupplystatuschanged = null;
+        }
+    };
+
+    require("cordova/exec/proxy").add("Battery", BatteryWin10);
+    return;
+}
+
 
 var stopped;
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -20,16 +20,22 @@
  */
 
 /* jshint jasmine: true */
-/* global WinJS */
+/* global Windows, WinJS */
 
 exports.defineAutoTests = function () {
-    var isWindowsStore = (cordova.platformId == "windows8") || (cordova.platformId == "windows" && !WinJS.Utilities.isPhone),
-        onEvent;
+    var hasPowerManagerAPI = Windows && Windows.System &&
+        Windows.System.Power && Windows.System.Power.PowerManager;
+
+    var batteryStatusUnsupported = cordova.platformId === "windows8" ||
+        // We don't test battery status on Windows when there is no corresponding APIs available
+        cordova.platformId === "windows" && !(hasPowerManagerAPI || WinJS.Utilities.isPhone);
+
+    var onEvent;
 
     describe('Battery (navigator.battery)', function () {
 
         it("battery.spec.1 should exist", function () {
-            if (isWindowsStore) {
+            if (batteryStatusUnsupported) {
                 pending('Battery status is not supported on windows store');
             }
 
@@ -42,7 +48,7 @@ exports.defineAutoTests = function () {
         describe("batterystatus", function () {
 
             afterEach(function () {
-                if (!isWindowsStore) {
+                if (!batteryStatusUnsupported) {
                     try {
                         window.removeEventListener("batterystatus", onEvent, false);
                     }
@@ -53,7 +59,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.2 should fire batterystatus events", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -78,7 +84,7 @@ exports.defineAutoTests = function () {
         describe("batterylow", function () {
 
             afterEach(function () {
-                if (!isWindowsStore) {
+                if (!batteryStatusUnsupported) {
                     try {
                         window.removeEventListener("batterylow", onEvent, false);
                     }
@@ -89,7 +95,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.3 should fire batterylow event (30 -> 20)", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -116,7 +122,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.3.1 should fire batterylow event (30 -> 19)", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -142,7 +148,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.3.2 should not fire batterylow event (5 -> 20)", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -168,7 +174,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.3.3 batterylow event(21 -> 20) should not fire if charging", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -197,7 +203,7 @@ exports.defineAutoTests = function () {
         describe("batterycritical", function () {
 
             afterEach(function () {
-                if (!isWindowsStore) {
+                if (!batteryStatusUnsupported) {
                     try {
                         window.removeEventListener("batterycritical", onEvent, false);
                     }
@@ -208,7 +214,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.4 should fire batterycritical event (19 -> 5)", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -235,7 +241,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.4.1 should fire batterycritical event (19 -> 4)", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -262,7 +268,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.4.2 should fire batterycritical event (100 -> 4) when decreases", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -288,7 +294,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.4.3 should not fire batterycritical event (4 -> 5) when increasing", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 
@@ -314,7 +320,7 @@ exports.defineAutoTests = function () {
             });
 
             it("battery.spec.4.4 should not fire batterycritical event (6 -> 5) if charging", function (done) {
-                if (isWindowsStore) {
+                if (batteryStatusUnsupported) {
                     pending('Battery status is not supported on windows store');
                 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows (specifically Windows 10)

### What does this PR do?
Adds support for Windows 10

### What testing has been done on this change?
Manual testing

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

