### PR TITLE
Fix: @cordova 7-8 Error: Failed to fetch plugin cordova-plugin-batter…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-battery-status",
-  "version": "2.0.2-dev",
+  "version": "2.0.3",
   "description": "Cordova Battery Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,9 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
       id="cordova-plugin-battery-status"
-      version="2.0.2-dev">
+      name="cordova-plugin-battery-status"
+      spec="2.0.3"
+      version="2.0.3">
     <name>Battery</name>
     <description>Cordova Battery Plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
## Error Logs

```sh
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Failed to get absolute path to installed module()
````

### Platforms affected
## Android


## Description: 

I cannot install the plugin with` cordova 7.1.0` or `cordova 8.0.0`.
The error above is present when i try to install the plugins