### PR TITLE
(ios) fixed no initial notification

### DIFF
--- a/src/ios/CDVBattery.m
+++ b/src/ios/CDVBattery.m
@@ -112,6 +112,8 @@
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateBatteryStatus:)
                                                      name:UIDeviceBatteryLevelDidChangeNotification object:nil];
     }
+    // push out the first update immediately
+    [self updateBatteryStatus:nil];
 }
 
 /* turn off battery monitoring */


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

On iOS, no `batterystatus` events are emitted until the battery level changes. This is a problem because an app should be able to find out what the battery level is without waiting an arbitrarily long time for it to change. (If a device stays plugged in and at 100%, it might never change at all.) Android, by comparison, emits immediately.

### Description
<!-- Describe your changes in detail -->

Calls `updateBatteryStatus` every time `start` runs, so that new listeners get a value immediately.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Confirmed using that `window.addEventListener('batterystatus', v => console.log(v);` produces immediate output, which it did not do before the change. Also validated in our app.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
