### PR TITLE
[Android] Response current battery status after subscribe event

### DIFF
--- a/src/android/BatteryListener.java
+++ b/src/android/BatteryListener.java
@@ -71,7 +71,8 @@ public class BatteryListener extends CordovaPlugin {
                         updateBatteryInfo(intent);
                     }
                 };
-                webView.getContext().registerReceiver(this.receiver, intentFilter);
+                Intent batteryStatus = webView.getContext().registerReceiver(this.receiver, intentFilter);
+                updateBatteryInfo(batteryStatus);
             }
 
             // Don't return any result now, since status results will be sent when events come in from broadcast receiver


### PR DESCRIPTION
At current, we could not get current battery status of the device if the event not fired (battery changed). So I add this patch to fix this issue.